### PR TITLE
Add presentations and external comms section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ strategy
 :maxdepth: 2
 resources/accounts
 resources/communication
+resources/external-communication
 development/conventions
 meetings/index
 ```

--- a/docs/resources/accounts.md
+++ b/docs/resources/accounts.md
@@ -13,6 +13,13 @@ Anybody can access these assets, though only core team members can edit them.
 We have [a shared Google Drive](https://drive.google.com/drive/folders/1lg4YpS3BpMnra4bVmkwfaTmYGYn42l3d?usp=sharing) where we store some assets like presentations and documents.
 Access to this Google Drive is restricted to core team members.
 
+Some useful things in the drive:
+
+- [Presentation slides for re-use by team members](#external-communication:presentations)
+- [The original grant that funded this project](https://drive.google.com/drive/folders/1VV05Jg3PvT_-jr4PoMsgS7kGuv40ERcs?usp=share_link)
+
+If there's shared information that would benefit from being in this Drive, please add it and link it here.
+
 ## `ebp-bot`
 
 We have a GitHub user that is dedicated to automation and scripting for the organization.
@@ -21,3 +28,7 @@ It has maintain permissions over Executable Books repositories, and we use its *
 This allows us to have programmatic access to EB resources without requiring a single team member to provide an access token.
 
 Ask a {team}`Core Team` member for access to the `@ebp-bot` account.
+
+## Social media
+
+See [](#external-communication:social).

--- a/docs/resources/external-communication.md
+++ b/docs/resources/external-communication.md
@@ -1,0 +1,34 @@
+# External communication
+
+These sections cover our practices and resources for communicating _outside_ of the project.
+
+## Blog
+
+We have a blog at [`executablebooks.org/en/latest/blog`](https://executablebooks.org/en/latest/blog/).
+This is most-often used for major project updates, but can also be used to discuss particular decisions or features in more detail, give general updates about what we are up to, etc.
+Generally speaking, we post under a generic "Executable Books" author byline, keep doing this until we define authorship guidelines for posts.
+
+(external-communication:social)=
+## Social media accounts
+
+We have two Twitter accounts as a centralized place where people can follow to learn about updates in our project.
+
+- [`@executablebooks`](https://twitter.com/executablebooks): Covers general project updates and the broader Jupyter Book, Sphinx, etc ecosystem.
+- [`@myst_tools`](https://twitter.com/myst_tools): Specific to MyST Markdown, open MEP proposals and their decisions, syntax updates, etc.
+
+We use these accounts to "push" information and boost the visibility of the project.
+We do not use them to engage in discourse with others on social media.
+
+Use these accounts to announce new releases and major features, upcoming events, and generally helpful information to our community.
+
+(external-communication:presentations)=
+## Giving presentations
+
+In some cases team members may be asked to give presentations on behalf of the Executable Books project.
+We do not yet have a formal policy for giving presentations.
+In the meantime, the [JupyterHub external communications practices](https://jupyterhub-team-compass.readthedocs.io/en/latest/practices/external-communication.html) are a good place to start.
+
+### Presentation resources
+
+[Our `Talks/` folder in the Google Drive](https://drive.google.com/drive/folders/1ZWPEevJ5feJxzGlW_Q4ykugXUujChI93?usp=share_link) has several slides from old talks that have been given by team members.
+If you give a talk, consider adding it so that others may learn or re-use the content.


### PR DESCRIPTION
Recently @mmcky was asking about a place to access old presentations about the Executable Books project. We actually have a folder in our google drive for this already, it just wasn't documented. So this PR adds brief mention of this folder, along with a broader set of guidelines for our current "external communications" methods, and how we are currently running them.

In the future we might want to formalize this (e.g. I've linked to the jupyterhub team compass comms guidelines as a start) but for now just wanted to describe what I think we're already doing.